### PR TITLE
Optimization: avoid string interpolation when writing to IO

### DIFF
--- a/src/nats/connection.cr
+++ b/src/nats/connection.cr
@@ -496,20 +496,21 @@ module NATS
     end
 
     private def send_connect
-      cs = {
-        :verbose  => false,
-        :pedantic => @pedantic,
-        :lang     => LANG,
-        :version  => VERSION,
-        :protocol => 1,
-      }
-      cs[:name] = @name.to_s if @name
-
-      cs[:user] = @user.to_s if @user
-      cs[:pass] = @pass.to_s if @pass
-
       @socket << "CONNECT "
-      cs.to_json(@socket)
+      JSON.build(@socket) do |json|
+        json.object do
+          json.field "verbose", false
+          json.field "pedantic", @pedantic
+          json.field "lang", LANG
+          json.field "version", VERSION
+          json.field "protocol", 1
+
+          json.field "name", @name.to_s if @name
+
+          json.field "user", @user.to_s if @user
+          json.field "pass", @pass.to_s if @pass
+        end
+      end
       @socket << "\r\n"
     end
   end

--- a/src/nats/nuid.cr
+++ b/src/nats/nuid.cr
@@ -60,7 +60,7 @@ module NATS
     def randomize_prefix!
       @prefix = String::Builder.build(PREFIX_LENGTH) do |io|
         Random::Secure.random_bytes(@pre_bytes)
-        @pre_bytes.each { |n| io << "#{DIGITS[n % BASE]}" }
+        @pre_bytes.each { |n| io << DIGITS[n % BASE] }
       end
     end
 


### PR DESCRIPTION
From the commit message:

> A string interpolation uses `String.build` behind the scene to create a new String instance. When writing to an IO we can avoid this extra memory allocation by writing directly to an IO.

In Crystal you can write any object to an `IO` by doing:

```crystal
io << object
```

This will in turn call `object.to_s(io)` which will try to dump the string representation of the object into `io` without allocating memory if possible.

I did the refactors trying to preserve the existing code's logic. In some cases `PUB_SLICE` is used, in others `"PUB "`. Maybe everything could be replaced to use string literals like "PUB " and "SUB ": there's no performance penalty in doing, there's less code (less constants) and it might be more readable. But it's something I didn't do in this PR.

Then  apparently there were two `publish_with_reply` overloads but with the same signature so the latter won. I think the `msg` argument in the second overload wasn't supposed to be there so I removed it, but let me know if that's not the case.

To benchmark the many `publish` methods I used a code like this:

```crystal
require "./src/nats"

uri = URI.parse("nats://127.0.0.1:4323")
nc = NATS::Connection.new(uri)

time = Time.now
20_000_000.times do |i|
  nc.publish("hello world", "hi there!")
  nc.flush if i % 10_000 == 0
end
puts Time.now - time
```

If I don't call `nc.flush` it eventually breaks, I think, because there's no other fiber to flush, I'm not sure. I wanted to use `Benchmark.ips` from the standard library but I couldn't because of that error (which is probably on my side because of my limited understanding of the protocol).

Before this PR the above code takes 4.96 seconds. With the new code it takes 2.83 seconds. So it might be the case that performance is doubled in general but I'm not sure. The same happens with other `publish` methods.

Finally, there's a `to_json` call somewhere that was used inside an interpolation. Here I did the same: there's a `to_json(io)` overload that will write the JSON representation of something without allocating any memory.

I'm sure there are other optimizations, but I'd like to try them once I know which benchmarks you used to try everything out. For example one other optimization might be to make `Msg` be a `struct` instead of a `class` because it looks like it's a small immutable type, so memory allocation could be avoided there too.