### PR TITLE
Update for Crystal 0.32+

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -14,6 +14,6 @@ targets:
   nats-req:
     main: bin/nats-req.cr
 
-crystal: 0.30.1
+crystal: 0.32.0
 
 license: Apache 2

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -45,11 +45,11 @@ class NATSServer
   end
 
   def wait_for_server(uri, max_wait = 5)
-    start = Time.now
+    start = Time.monotonic
     wait = Time::Span.new(0, 0, max_wait)
-    while (Time.now - start < wait) # Wait max_wait seconds max
+    while (Time.monotonic - start < wait) # Wait max_wait seconds max
       return if server_running?(uri)
-      sleep(20.millisecond)
+      sleep(20.milliseconds)
     end
     raise "Server not started, can not connect"
   end

--- a/src/nats/connection.cr
+++ b/src/nats/connection.cr
@@ -508,8 +508,8 @@ module NATS
       if match = line.match(INFO)
         info_json = match.captures.first
         @server_info = JSON.parse(info_json.to_s).as_h
-        unless @server_info[:max_payload]?.nil?
-          @max_payload = @server_info[:max_payload].as_i
+        if max_payload = @server_info["max_payload"]?
+          @max_payload = max_payload.as_i
         end
       else
         raise "INFO not valid"

--- a/src/nats/connection.cr
+++ b/src/nats/connection.cr
@@ -306,11 +306,11 @@ module NATS
 
         @waiting_count.add 1
       end
+      send_flush
 
       InternalSubscription.new(sid, self).tap do |sub|
         @subs[sid] = sub
       end
-      send_flush
     end
 
     # Subscribe to a given subject. Will yield to the callback provided with the message received.
@@ -329,11 +329,11 @@ module NATS
 
         @waiting_count.add 1
       end
+      send_flush
 
       Subscription.new(sid, self, callback).tap do |sub|
         @subs[sid] = sub
       end
-      send_flush
     end
 
     # Subscribe to a given subject with the queue group. Will yield to the callback provided with the message received.
@@ -354,11 +354,11 @@ module NATS
 
         @waiting_count.add 1
       end
+      send_flush
 
       Subscription.new(sid, self, callback).tap do |sub|
         @subs[sid] = sub
       end
-      send_flush
     end
 
     def subscribe(subject : String, queue : String | Nil, &callback : Msg ->)

--- a/src/nats/connection.cr
+++ b/src/nats/connection.cr
@@ -145,7 +145,7 @@ module NATS
       @out.synchronize do
         yield
       end
-      @flush.send(true) if @flush.empty?
+      send_flush
     end
 
     private def check_size(data)
@@ -176,7 +176,7 @@ module NATS
         @socket.write(data)
         @socket.write(CR_LF_SLICE)
       end
-      @flush.send(true) if @flush.empty?
+      send_flush
     end
 
     # Publishes an empty message to a given subject.
@@ -195,7 +195,7 @@ module NATS
         @socket.write(" 0\r\n\r\n".to_slice)
       end
 
-      @flush.send(true) if @flush.empty?
+      send_flush
     end
 
     # Publishes a messages to a given subject with a reply subject.
@@ -225,7 +225,7 @@ module NATS
         @socket.write(data)
         @socket.write(CR_LF_SLICE)
       end
-      @flush.send(true) if @flush.empty?
+      send_flush
     end
 
     # Flush will flush the connection to the server. Can specify a *timeout*.
@@ -250,7 +250,7 @@ module NATS
       String::Builder.build(TOKEN_LENGTH) do |io|
         (0...TOKEN_LENGTH).each do
           io << NUID::DIGITS[rn % NUID::BASE]
-          rn /= NUID::BASE
+          rn //= NUID::BASE
         end
       end
     end
@@ -299,7 +299,7 @@ module NATS
         @socket << ' ' << sid
         @socket.write(CR_LF_SLICE)
       end
-      @flush.send(true) if @flush.empty?
+      send_flush
       InternalSubscription.new(sid, self).tap do |sub|
         @subs[sid] = sub
       end
@@ -319,7 +319,7 @@ module NATS
         @socket << ' ' << sid
         @socket.write(CR_LF_SLICE)
       end
-      @flush.send(true) if @flush.empty?
+      send_flush
       Subscription.new(sid, self, callback).tap do |sub|
         @subs[sid] = sub
       end
@@ -341,7 +341,7 @@ module NATS
         @socket << ' ' << sid
         @socket.write(CR_LF_SLICE)
       end
-      @flush.send(true) if @flush.empty?
+      send_flush
       Subscription.new(sid, self, callback).tap do |sub|
         @subs[sid] = sub
       end
@@ -359,7 +359,7 @@ module NATS
         @socket << sid
         @socket.write(CR_LF_SLICE)
       end
-      @flush.send(true) if @flush.empty?
+      send_flush
     end
 
     # Close a connection to the NATS server.
@@ -371,10 +371,7 @@ module NATS
     def close
       return if @closed
       @closed = true
-      @out.synchronize do
-        flush_outbound
-        @socket.flush
-      end
+      flush_outbound
       @socket.close
       @subs.each { |sid, sub| sub.unsubscribe }
       # TODO(dlc) - pop any calls in flush.
@@ -540,6 +537,10 @@ module NATS
         end
       end
       @socket << "\r\n"
+    end
+
+    private def send_flush
+      @flush.send(true) if @flush.@queue.not_nil!.empty?
     end
   end
 end

--- a/src/nats/connection.cr
+++ b/src/nats/connection.cr
@@ -107,7 +107,6 @@ module NATS
       spawn inbound
 
       # spawn for our outbound
-      @flush = Channel(Bool?).new(8)
       spawn outbound
     end
 
@@ -145,7 +144,6 @@ module NATS
       @out.synchronize do
         yield
       end
-      send_flush
     end
 
     private def check_size(data)
@@ -176,7 +174,6 @@ module NATS
         @socket.write(data)
         @socket.write(CR_LF_SLICE)
       end
-      send_flush
     end
 
     # Publishes an empty message to a given subject.
@@ -194,8 +191,6 @@ module NATS
         @socket.write(subject.to_slice)
         @socket.write(" 0\r\n\r\n".to_slice)
       end
-
-      send_flush
     end
 
     # Publishes a messages to a given subject with a reply subject.
@@ -225,17 +220,6 @@ module NATS
         @socket.write(data)
         @socket.write(CR_LF_SLICE)
       end
-      send_flush
-    end
-
-    # Flush will flush the connection to the server. Can specify a *timeout*.
-    def flush(timeout = 2.second)
-      ch = Channel(Nil).new
-      @pongs.push(ch)
-      @out.synchronize { @socket.write(PING_SLICE) }
-      flush_outbound
-      spawn { sleep timeout; ch.close }
-      ch.receive rescue {raise "Flush Timeout"}
     end
 
     def new_inbox
@@ -299,7 +283,7 @@ module NATS
         @socket << ' ' << sid
         @socket.write(CR_LF_SLICE)
       end
-      send_flush
+
       InternalSubscription.new(sid, self).tap do |sub|
         @subs[sid] = sub
       end
@@ -319,7 +303,7 @@ module NATS
         @socket << ' ' << sid
         @socket.write(CR_LF_SLICE)
       end
-      send_flush
+
       Subscription.new(sid, self, callback).tap do |sub|
         @subs[sid] = sub
       end
@@ -341,7 +325,7 @@ module NATS
         @socket << ' ' << sid
         @socket.write(CR_LF_SLICE)
       end
-      send_flush
+
       Subscription.new(sid, self, callback).tap do |sub|
         @subs[sid] = sub
       end
@@ -359,7 +343,6 @@ module NATS
         @socket << sid
         @socket.write(CR_LF_SLICE)
       end
-      send_flush
     end
 
     # Close a connection to the NATS server.
@@ -465,8 +448,6 @@ module NATS
       close
     end
 
-    @flush_counter = 0
-
     private def flush_outbound
       @out.synchronize do
         @socket.flush
@@ -475,10 +456,8 @@ module NATS
 
     private def outbound
       until closed?
-        fs = @flush.receive
-        break if fs.nil?
+        sleep 10.milliseconds
         flush_outbound
-        Fiber.yield
       end
     end
 
@@ -537,10 +516,6 @@ module NATS
         end
       end
       @socket << "\r\n"
-    end
-
-    private def send_flush
-      @flush.send(true) if @flush.@queue.not_nil!.empty?
     end
   end
 end

--- a/src/nats/nuid.cr
+++ b/src/nats/nuid.cr
@@ -48,7 +48,15 @@ module NATS
       s_10 = DIGITS[l % BASE]
       # Ugly, but parallel assignment is slightly faster here...
       s_09, s_08, s_07, s_06, s_05, s_04, s_03, s_02, s_01 = \
-         (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE]), (l /= BASE; DIGITS[l % BASE])
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE]),
+         (l //= BASE; DIGITS[l % BASE])
       "#{@prefix}#{s_01}#{s_02}#{s_03}#{s_04}#{s_05}#{s_06}#{s_07}#{s_08}#{s_09}#{s_10}"
     end
 


### PR DESCRIPTION
Changes:

- Use `//` for integer division since `Number#/` always does floating-point division in 0.32+
- `Time.now` has been removed, but the spot where it was being used was better served by a monotonic clock anyway
- `Channel(T)#empty?` has been removed
  - I don't like my solution since it uses ivars directly on the `Channel`, but I couldn't come up with a better way to do the same thing
  - I tried removing the conditional but it slowed down publishing on my machine by an order of magnitude
- Remove recursive mutex locking
  - This doesn't work in 0.31+