### PR TITLE
Optimize subscribe performance

### DIFF
--- a/src/nats/connection.cr
+++ b/src/nats/connection.cr
@@ -437,13 +437,13 @@ module NATS
     # Should try manual blind read and hand rolled parser similar to Golang. Also make sure Channels is not slowdown.
     private def inbound
       until closed?
-        case data = @socket.gets(CR_LF)
+        case data = @socket.gets('\n')
         when MSG
           bytesize = $5.to_i
           sid = $2.to_i
           payload = Bytes.new(bytesize)
           @socket.read_fully?(payload) || raise "Unexpected EOF"
-          @socket.gets(CR_LF)
+          @socket.gets('\n')
           sub = @subs[sid]
           sub.send(Msg.new($1, payload, $4?, self)) unless sub.nil?
         when PING

--- a/src/nats/msg.cr
+++ b/src/nats/msg.cr
@@ -24,7 +24,7 @@ module NATS
   #   puts "Raw Data is #{msg.data}"
   # end
   # ```
-  class Msg
+  struct Msg
     getter subject : String
     getter reply : String?
     getter data : Bytes
@@ -33,7 +33,7 @@ module NATS
 
     # :nodoc:
     def to_s(io : IO)
-      io << String.new(data)
+      io.write data
     end
 
     # :nodoc:


### PR DESCRIPTION
`IO#gets(delimiter : String)` is slow, but `IO#gets(delimiter : Char)` is faster. I was able to achieve a ~43% improvement in subscriber throughput (1.86M vs 1.27M) by using a Char instead of a String delimeter.

This appears to be safe since there isn't anywhere that a `\n` could appear in either of these cases where a `\r` wouldn't precede it. So as long as the server is doing the right thing, we should be good.